### PR TITLE
Support for Raspberry Pi 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ package:
 image:
 	docker build --tag watsor.base     --file docker/Dockerfile.base     .
 	docker build --tag watsor.gpu.base --file docker/Dockerfile.gpu.base .
+	docker build --tag watsor.pi4.base --file docker/Dockerfile.pi4.base .
 	docker build --tag watsor          --file docker/Dockerfile          .
 	docker build --tag watsor.gpu      --file docker/Dockerfile.gpu      .
+	docker build --tag watsor.pi4      --file docker/Dockerfile.pi4 .
 
 all: plugin test package

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Watsor detects objects in video stream using deep learning-based approach. Intended primarily for surveillance it works in sheer real-time analysing the most recent frame to deliver fastest reaction against a detected threat.
 
+## Table of contents
+  * [What it does](#what-it-does)
+  * [Getting started](#getting-started)
+  * [Configuration](#configuration)
+    + [Cameras](#cameras)
+    + [FFmpeg decoder and encoder](#ffmpeg-decoder-and-encoder)
+    + [Detection classes and filters](#detection-classes-and-filters)
+    + [Zones and masks](#zones-and-masks)
+    + [Tips](#tips)
+    + [Environmental variables](#environmental-variables)
+    + [Secrets](#secrets)
+    + [HomeAssistant integration](#homeassistant-integration)
+  * [Running Watsor](#running-watsor)
+    + [Docker](#docker)
+    + [Python module](#python-module)
+      - [Object detection models](#object-detection-models)
+      - [Hardware acceleration drivers](#hardware-acceleration-drivers)
+  * [Building from source](#building-from-source)
+  * [Troubleshooting](#troubleshooting)
+  * [Credits](#credits)
+  * [License](#license)
+
 ## What it does
 
 - Performs smart detection based on artificial neural networks significantly reducing false positives in video surveillance.
@@ -92,7 +114,7 @@ ffmpeg:
 ```
 </details>
 
-`ffmpeg.encoder` is optional and intended for the recording or broadcasting of video stream with rendered object detections. The recording is suitable for on demand streaming as the video is stored in a file such as `.m3u8` (HLS) or `.mp4` and can be re-watched. The broadcasting means the video is being recorded in real time and the viewer can only watch it as it is streaming. To broadcast the video with rendered object detections over HTTP set `-f mpegts` option in teh encoder and remove the camera's `output` key. The link to the video stream can be grabbed from Watsor's home page and opened in media player such as [VLC](https://en.wikipedia.org/wiki/VLC_media_player).  
+`ffmpeg.encoder` is optional and intended for the recording or broadcasting of video stream with rendered object detections. The recording is suitable for on demand streaming as the video is stored in a file such as `.m3u8` (HLS) or `.mp4` and can be re-watched. The broadcasting means the video is being recorded in real time and the viewer can only watch it as it is streaming. To broadcast the video with rendered object detections over HTTP set `-f mpegts` option in the encoder and remove the camera's `output` key. The link to the video stream can be grabbed from Watsor's home page and opened in media player such as [VLC](https://en.wikipedia.org/wiki/VLC_media_player).  
 
 When broadcasting live video stream in MPEG-TS be aware of noticeable [latency](https://trac.ffmpeg.org/wiki/StreamingGuide#Latency), which is unavoidable due to the nature of video encoding algorithm. Bear in mind the media player introduces a latency of its own as it buffers the feed. To watch the video with rendered object detections in sheer real-time with zero latency open Motion JPEG URL of the camera feed.
 
@@ -277,8 +299,10 @@ Watsor works well on Pyhton 3.6, 3.7, 3.8. Use a [virtual environment](https://d
 1. Install module:
 
    ```bash
-   python3 -m pip install watsor
+   python3 -m pip install[cpu] watsor
    ```
+   
+   If you've got a [hardware accelerator](#hardware-acceleration-drivers) or are installing the application on a tiny board like Raspberry Pi, take a look at _extra_ profiles `coral`, `cuda` or `lite` in [setup.py](setup.py). The dependencies listed in those profiles need to be installed in advance. Refer to the documentation of the device or take a look at one of the [Docker files](docker/) to understand how the dependencies are installed. 
 
 2. Create `model/` folder, download, unpack and prepare the [object detection models](#object-detection-models) (see the section below).
 
@@ -308,10 +332,11 @@ The models are available in several formats depending on the device the inferenc
 
 | Device | Filename | MobileNet v1 | MobileNet v2 | Inception v2 |
 |---|---|---|---|---|
-| CPU | `model/cpu.pb` | [MobileNet v1](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz) | [MobileNet v2](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v2_coco_2018_03_29.tar.gz) | [Inception v2](http://download.tensorflow.org/models/object_detection/ssd_inception_v2_coco_2018_01_28.tar.gz) | 
 | Coral | `model/edgetpu.tflite` | [MobileNet v1](https://github.com/google-coral/edgetpu/raw/master/test_data/ssd_mobilenet_v1_coco_quant_postprocess_edgetpu.tflite) | [MobileNet v2](https://github.com/google-coral/edgetpu/raw/master/test_data/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite) | N/A |
 | Nvidia CUDA GPU | `model/gpu.uff` | [MobileNet v1](https://github.com/dusty-nv/jetson-inference/releases/download/model-mirror-190618/SSD-Mobilenet-v1.tar.gz) | [MobileNet v2](https://github.com/dusty-nv/jetson-inference/releases/download/model-mirror-190618/SSD-Mobilenet-v2.tar.gz) | [Inception v2](https://github.com/dusty-nv/jetson-inference/releases/download/model-mirror-190618/SSD-Inception-v2.tar.gz) |
- 
+| CPU | `model/cpu.pb` | [MobileNet v1](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz) | [MobileNet v2](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v2_coco_2018_03_29.tar.gz) | [Inception v2](http://download.tensorflow.org/models/object_detection/ssd_inception_v2_coco_2018_01_28.tar.gz) |
+| Raspberry Pi & others | `model/cpu.tflite` | [MobileNet v1](https://storage.googleapis.com/download.tensorflow.org/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip) | N/A | N/A | 
+  
 #### Hardware acceleration drivers
 
 Use of hardware accelerator is optional, but highly recommended as object detection as such requires much computation. Speaking of number of frames per second the CPU of a desktop computer can process just 24 FPS of the lightest model, but an accelerator can boost the performance up to 5 times. Two accelerators connected or installed can handle 200 FPS, which is more than enough for handling several video cameras.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,13 +1,13 @@
 # Optional HTTP server configuration and authentication.
-# http:
-  # port: 8080
+http:
+  port: 8080
   # username: !env_var "USERNAME john"
   # password: !env_var "PASSWORD qwerty"
 
 
 # Optional MQTT client configuration and authentication.
-#mqtt:
-  # host: localhost
+mqtt:
+  host: localhost
   # port: 1883
   # username: !secret mqtt_username
   # password: !secret mqtt_password
@@ -21,12 +21,12 @@ ffmpeg:
     - -loglevel
     -  error
     - -nostdin
-    - -hwaccel
-    -  vaapi
-    - -hwaccel_device
-    -  /dev/dri/renderD128
-    - -hwaccel_output_format
-    -  yuv420p
+    - -hwaccel                   # These options enable hardware acceleration of
+    -  vaapi                     # video de/encoding. You need to check what methods
+    - -hwaccel_device            # (if any) are supported by running the command:
+    -  /dev/dri/renderD128       #    ffmpeg -hwaccels
+    - -hwaccel_output_format     # Then refer to the documentation of the method
+    -  yuv420p                   # to enable it in ffmpeg. Remove if not sure.
     - -fflags
     -  nobuffer
     - -flags

--- a/docker/Dockerfile.gpu.base
+++ b/docker/Dockerfile.gpu.base
@@ -34,7 +34,7 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_DRIVER_CAPABILITIES compute,video,utility
 ENV NVIDIA_REQUIRE_CUDA "cuda>=10.2 brand=tesla,driver>=384,driver<385 brand=tesla,driver>=396,driver<397 brand=tesla,driver>=410,driver<411 brand=tesla,driver>=418,driver<419"
 
 #

--- a/docker/Dockerfile.pi4
+++ b/docker/Dockerfile.pi4
@@ -1,0 +1,22 @@
+FROM watsor.pi4.base
+
+RUN [ "cross-build-start" ]
+
+COPY . /opt/watsor
+
+WORKDIR /opt/watsor
+
+RUN python3 -m pip install -r requirements.txt --no-deps && \
+    rm -r /opt/watsor
+
+RUN [ "cross-build-end" ]
+
+USER watsor
+
+WORKDIR /
+
+CMD python3 -m watsor.main \
+    --log-path /var/log/watsor \
+    --log-level ${LOG_LEVEL:-info} \
+    --config /etc/watsor/config.yaml \
+    --model-path /usr/share/watsor/model

--- a/docker/Dockerfile.pi4.base
+++ b/docker/Dockerfile.pi4.base
@@ -1,0 +1,135 @@
+FROM balenalib/raspberrypi4-64-ubuntu:bionic AS base
+
+RUN [ "cross-build-start" ]
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TF_CPP_MIN_LOG_LEVEL=2
+
+# Install basic packages
+RUN install_packages \
+    apt-transport-https \
+    ca-certificates \
+    software-properties-common \
+    build-essential \
+    wget \
+    gnupg \
+    unzip
+
+# Install FFmpeg and some prerequisites
+RUN install_packages \
+    ffmpeg \
+    zlib1g-dev \
+    libpng-dev libjpeg-dev \
+    libgeos-dev \
+    libswscale-dev \
+    libtbb2 libtbb-dev \
+    libopenblas-dev libatlas-base-dev libblas-dev \
+    liblapack-dev \
+    libprotobuf-dev
+
+# Install Python and dependencies
+RUN install_packages \
+    python3-dev \
+    python3-pip \
+    python3-scipy && \
+    python3 -m pip install --upgrade \
+        pip \
+        setuptools \
+        wheel && \
+    python3 -m pip install --upgrade \
+        PyYaml \
+        Pillow \
+        cerberus \
+        numpy \
+        shapely \
+        werkzeug \
+        paho-mqtt \
+        https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp36-cp36m-linux_aarch64.whl
+
+# Build OpenCV from sources
+ENV OPENCV_VERSION="4.1.1"
+
+RUN install_packages \
+    cmake \
+    gfortran \
+    gcc-arm* \
+    protobuf-compiler \
+    pkg-config && \
+    wget -q https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip && \
+    unzip ${OPENCV_VERSION}.zip -d /opt && \
+    rm /${OPENCV_VERSION}.zip  && \
+    mv /opt/opencv-${OPENCV_VERSION} /opt/opencv && \
+    mkdir /opt/opencv/cmake_binary && \
+    cd /opt/opencv/cmake_binary && \
+    cmake \
+      -D ENABLE_NEON=OFF \
+      -D ENABLE_VFPV3=OFF \
+      -D WITH_OPENMP=ON \
+      -D WITH_TBB=ON -D BUILD_TBB=ON \
+      -D WITH_JPEG=ON -D BUILD_JPEG=ON \
+      -D WITH_PNG=ON -D BUILD_PNG=ON \
+      -D WITH_TIFF=OFF -D BUILD_TIFF=OFF \
+      -D WITH_OPENEXR=OFF \
+      -D WITH_IPP=OFF \
+      -D WITH_WEBP=OFF \
+      -D WITH_FFMPEG=OFF \
+      -D WITH_1394=OFF \
+      -D WITH_GTK=OFF \
+      -D WITH_OPENCL=OFF \
+      -D WITH_QT=OFF \
+      -D WITH_V4L=OFF \
+      -D WITH_JASPER=OFF \
+      -D BUILD_TESTS=OFF \
+      -D BUILD_PERF_TESTS=OFF \
+      -D BUILD_EXAMPLES=OFF \
+      -D BUILD_SHARED_LIBS=ON \
+      -D CMAKE_BUILD_TYPE=RELEASE \
+      -D OPENCV_EXTRA_EXE_LINKER_FLAGS=-latomic \
+      -D OPENCV_ENABLE_NONFREE=ON \
+      -D INSTALL_C_EXAMPLES=OFF \
+      -D INSTALL_PYTHON_EXAMPLES=OFF \
+      -D BUILD_NEW_PYTHON_SUPPORT=ON \
+      -D BUILD_opencv_python2=OFF \
+      -D BUILD_opencv_python3=ON \
+      -D BUILD_opencv_java=OFF \
+      -D OPENCV_GENERATE_PKGCONFIG=ON \
+      .. && \
+    make -j"$(nproc)" install && \
+    ldconfig && \
+    rm -r /opt/opencv && \
+    apt-get purge --autoremove -y \
+    cmake \
+    gfortran \
+    gcc-arm* \
+    protobuf-compiler \
+    pkg-config
+
+# Install the Edge TPU runtime
+RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list && \
+    wget -q -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    install_packages \
+        libedgetpu1-std \
+        python3-edgetpu
+
+# Cleanup and dedicated user
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && apt-get autoclean -y && \
+    mkdir /etc/watsor /usr/share/watsor /var/log/watsor && \
+    addgroup -gid 1001 watsor && \
+    adduser -uid 1001 -gid 1001 -gecos watsor -home /usr/share/watsor --no-create-home --disabled-password watsor && \
+    usermod -a --groups video,plugdev watsor && \
+    chown -R watsor /etc/watsor /usr/share/watsor /var/log/watsor
+
+# Download object detection models
+RUN mkdir model && \
+    wget -q https://github.com/google-coral/edgetpu/raw/master/test_data/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite -O model/edgetpu.tflite --trust-server-names && \
+    wget -q https://storage.googleapis.com/download.tensorflow.org/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip -O model/cpu.zip && \
+    unzip model/cpu.zip detect.tflite -d model && \
+    mv model/detect.tflite model/cpu.tflite && \
+    rm model/cpu.zip && \
+    mv model /usr/share/watsor/model && \
+    chown -R watsor:watsor /usr/share/watsor/model
+
+EXPOSE 8080
+
+RUN [ "cross-build-end" ]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="UTF-8") as fh:
 
 setup(
     name="watsor",
-    version="1.0.1",
+    version="1.0.3",
     author="Alexander Smirnov",
     author_email="aliaksandr.smirnou@gmail.com",
     description="Object detection for video surveillance",
@@ -32,7 +32,6 @@ setup(
         'shapely',
         'werkzeug',
         'paho-mqtt',
-        'tensorflow',  # 'tflite_runtime',
     ],
     extras_require={
         'coral': [
@@ -41,6 +40,12 @@ setup(
         'cuda': [
             'pycuda',
             'tensorrt',
+        ],
+        'cpu': [
+            'tensorflow',
+        ],
+        'lite': [
+            'tflite_runtime',
         ],
         'dev': [
             'coverage',

--- a/watsor/detection/detector.py
+++ b/watsor/detection/detector.py
@@ -3,8 +3,7 @@ from typing import Dict
 from multiprocessing.sharedctypes import Array
 from watsor.stream.work import Work, Payload
 from watsor.stream.share import FrameBuffer, FramesPerSecond, InferenceTime
-from watsor.detection.tensorflow_cpu import TensorFlowObjectDetector
-from watsor.detection.devices import cuda_gpus, edge_tpus
+from watsor.detection.devices import cuda_gpus, edge_tpus, cpus
 
 _ALWAYS_USE_CPU = False
 
@@ -44,10 +43,12 @@ def create_object_detectors(delegate_class, stop_event, log_queue, frame_queue, 
                                                 'detector_args': (model_path, device)}))
 
     if _ALWAYS_USE_CPU or len(detectors) == 0:
-        detectors.append(ObjectDetector(delegate_class, gen_name(), stop_event, log_queue, frame_queue, frame_buffers,
-                                        kwargs={**kwargs,
-                                                'detector_class': TensorFlowObjectDetector,
-                                                'detector_args': (model_path,)}))
+        for clazz in cpus():
+            detectors.append(
+                ObjectDetector(delegate_class, gen_name(), stop_event, log_queue, frame_queue, frame_buffers,
+                               kwargs={**kwargs,
+                                       'detector_class': clazz,
+                                       'detector_args': (model_path,)}))
 
     return detectors
 

--- a/watsor/detection/devices.py
+++ b/watsor/detection/devices.py
@@ -80,3 +80,22 @@ def cuda_gpus():
         # Otherwise, try to use any available device
         for device in range(ndevices):
             yield device, TensorRTObjectDetector
+
+
+def cpus():
+    """Yields either TensorFlow or TensorFlow Lite cpu-based detector class
+    depending on what dependency is installed.
+    """
+    try:
+        from watsor.detection.tensorflow_cpu import TensorFlowObjectDetector
+        yield TensorFlowObjectDetector
+        return
+    except ImportError:
+        pass
+
+    try:
+        from watsor.detection.tensorflow_lite_cpu import TensorFlowLiteObjectDetector
+        yield TensorFlowLiteObjectDetector
+        return
+    except ImportError:
+        pass

--- a/watsor/detection/tensorflow_lite_cpu.py
+++ b/watsor/detection/tensorflow_lite_cpu.py
@@ -9,7 +9,7 @@ from watsor.stream.share import Detection
 
 
 class TensorFlowLiteObjectDetector:
-    """TensorFlow Lite inference on CPU is not used and was left just for the record.
+    """TensorFlow Lite inference on CPU is used on IoT devices.
     TensorFlow Lite running on desktop without any GPU delegate is 9 times worse than TensorFlow.
     """
 


### PR DESCRIPTION
This PR adds support for Raspberry Pi 4.
Watsor can be installed on the device either as Python module or using the Docker image, which is compatible with 64-bit OS only at the moment.

To get decent performance on a device such as Raspberry Pi one needs the Coral USB accelerator. Without the latter the detection in Raspberry is based on TensorFlow Lite, but most probably it won’t cope with more than 5 FPS of the lightest detection model. 

The Docker image supports USB devices with the help of UDEV flag (by adding `--env UDEV=1`).

The Docker image can be improved by rebuilding with NEON and VFPV3 options of OpenCV turned ON to enable native support of single and double-precision in Raspberry’s ARM Cortex-A72 CPU. It isn't know yet how much can be gained as far as OpenCV is not used for detection, but only to produce Motion JPEG and some video effects. The options can be enabled only when running the build on the Raspberry itself. I used cross build where these options are not available.