### PR TITLE
support for Raspberry Pi 3 and 4 (32-bit OS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,11 @@ package:
 image:
 	docker build --tag watsor.base     --file docker/Dockerfile.base     .
 	docker build --tag watsor.gpu.base --file docker/Dockerfile.gpu.base .
+	docker build --tag watsor.pi3.base --file docker/Dockerfile.pi3.base .
 	docker build --tag watsor.pi4.base --file docker/Dockerfile.pi4.base .
 	docker build --tag watsor          --file docker/Dockerfile          .
 	docker build --tag watsor.gpu      --file docker/Dockerfile.gpu      .
+	docker build --tag watsor.pi3      --file docker/Dockerfile.pi3 .
 	docker build --tag watsor.pi4      --file docker/Dockerfile.pi4 .
 
 all: plugin test package

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ The following table lists the available docker images:
 |---|---|
 | [watsor](https://hub.docker.com/r/smirnou/watsor) | x86-64 |
 | [watsor.gpu](https://hub.docker.com/r/smirnou/watsor.gpu) | x86-64 with Nvidia CUDA GPU  |
+| [watsor.pi3](https://hub.docker.com/r/smirnou/watsor.pi3) | Raspberry PI 3 or 4 with 32-bit OS |
 | [watsor.pi4](https://hub.docker.com/r/smirnou/watsor.pi4) | Raspberry PI 4 with 64-bit OS |  
 
 ### Python module

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Being applicable in CCTV, Watsor also suits other areas, where object detection 
 
 ## Getting started
 
-Watsor is written on Python 3 and ships mainly as [Python module](#python-module). The easiest way, however, is trying it in [Docker](#docker) as far as hardware drivers and models are bundled in the images.
+Watsor is written in Python 3 and ships mainly as [Python module](#python-module). The easiest way, however, is trying it in [Docker](#docker) as far as hardware drivers and models are bundled in the images.
 
 Regardless of how you run Watsor, you need to prepare configuration file, describing the cameras you've got and few other options such as types of detections and zones. Refer to the guide below.
 

--- a/docker/Dockerfile.pi3
+++ b/docker/Dockerfile.pi3
@@ -1,0 +1,22 @@
+FROM watsor.pi3.base
+
+RUN [ "cross-build-start" ]
+
+COPY . /opt/watsor
+
+WORKDIR /opt/watsor
+
+RUN python3 -m pip install -r requirements.txt --no-deps && \
+    rm -r /opt/watsor
+
+RUN [ "cross-build-end" ]
+
+USER watsor
+
+WORKDIR /
+
+CMD python3 -m watsor.main \
+    --log-path /var/log/watsor \
+    --log-level ${LOG_LEVEL:-info} \
+    --config /etc/watsor/config.yaml \
+    --model-path /usr/share/watsor/model

--- a/docker/Dockerfile.pi3.base
+++ b/docker/Dockerfile.pi3.base
@@ -1,0 +1,76 @@
+# The device types Debian Balena base images have the Raspbian package source added
+# and Raspbian userland pre-installed
+FROM balenalib/raspberrypi3-debian-python:3.7.7-buster
+
+RUN [ "cross-build-start" ]
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TF_CPP_MIN_LOG_LEVEL=2
+
+# Install basic packages
+RUN install_packages \
+    apt-transport-https \
+    ca-certificates \
+    software-properties-common \
+    build-essential \
+    wget \
+    gnupg \
+    unzip
+
+# Install FFmpeg with hardware acceleration support and some prerequisites
+RUN install_packages \
+    ffmpeg \
+    zlib1g \
+    libpng-dev libjpeg-dev \
+    libgeos-dev \
+    libopenblas-dev libatlas-base-dev libblas-dev \
+    libilmbase23 libgtk-3-0 libatk1.0-0 libpango-1.0-0 libjasper1 libopenexr23 libswscale5 libpangocairo-1.0-0 libtiff5 libcairo2 libwebp6 libgdk-pixbuf2.0-0 libcairo-gobject2
+
+# Install Python dependencies
+RUN python3 -m pip install --upgrade \
+        pip \
+        setuptools \
+        wheel && \
+    python3 -m pip install --upgrade \
+        PyYaml \
+        cerberus \
+        werkzeug \
+        paho-mqtt && \
+    python3 -m pip install --upgrade --extra-index-url https://www.piwheels.org/simple \
+        numpy \
+        scipy \
+        opencv-python-headless==4.1.0.25 \
+        Pillow \
+        Shapely && \
+    python3 -m pip install \
+        https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl
+
+# Install the Edge TPU runtime
+RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list && \
+    wget -q -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    install_packages \
+        libedgetpu1-std \
+        python3-edgetpu
+
+# Cleanup and dedicated user
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && apt-get autoclean -y && \
+    mkdir /etc/watsor /usr/share/watsor /var/log/watsor && \
+    addgroup -gid 1001 watsor && \
+    adduser -uid 1001 -gid 1001 -gecos watsor -home /usr/share/watsor --no-create-home --disabled-password watsor && \
+    usermod -a --groups video,plugdev watsor && \
+    chown -R watsor /etc/watsor /usr/share/watsor /var/log/watsor
+
+# Download object detection models
+RUN mkdir model && \
+    wget -q https://github.com/google-coral/edgetpu/raw/master/test_data/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite -O model/edgetpu.tflite --trust-server-names && \
+    wget -q https://storage.googleapis.com/download.tensorflow.org/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip -O model/cpu.zip && \
+    unzip model/cpu.zip detect.tflite -d model && \
+    mv model/detect.tflite model/cpu.tflite && \
+    rm model/cpu.zip && \
+    mv model /usr/share/watsor/model && \
+    chown -R watsor:watsor /usr/share/watsor/model
+
+EXPOSE 8080
+
+RUN [ "cross-build-end" ]

--- a/docker/Dockerfile.pi4.base
+++ b/docker/Dockerfile.pi4.base
@@ -104,6 +104,69 @@ RUN install_packages \
     protobuf-compiler \
     pkg-config
 
+# Build latest userland tools and FFmpeg with hardware acceleration support
+#RUN install_packages \
+#    libx264-dev \
+#    libx265-dev \
+#    cmake \
+#    git \
+#    gcc-arm* \
+#    g++-arm* \
+#    pkg-config && \
+#    cd / && \
+#    git clone --depth 1 https://github.com/raspberrypi/userland.git && \
+#    mkdir -p userland/build/arm-linux/release && \
+#    cd userland/build/arm-linux/release && \
+#    cmake \
+#        -DCMAKE_TOOLCHAIN_FILE="../../../makefiles/cmake/toolchains/aarch64-linux-gnu.cmake" \
+#        -DCMAKE_BUILD_TYPE="Release" \
+#        -DARM64="ON" \
+#        -DCMAKE_INSTALL_PREFIX="/opt/vc" \
+#        -DCMAKE_INSTALL_RPATH='${CMAKE_INSTALL_PREFIX}/lib' \
+#        ../../.. && \
+#    make -j"$(nproc)" install && \
+#    rm -rf userland && \
+#    cd / && \
+#    FFMPEG_VERSION=4.2.2 && \
+#    wget http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz && \
+#    tar zxf ffmpeg-${FFMPEG_VERSION}.tar.gz && \
+#    rm ffmpeg-${FFMPEG_VERSION}.tar.gz && \
+#    cd ffmpeg-${FFMPEG_VERSION} && \
+#    ./configure \
+#        --arch="aarch64" \
+#        --target-os="linux" \
+#        --prefix="/usr/local" \
+#        --enable-cross-compile \
+#        --toolchain=hardened \
+#        --enable-gpl \
+#        --enable-nonfree \
+#        --enable-avresample \
+#        --enable-libx264 \
+#        --enable-libx265 \
+#        --enable-omx \
+#        --enable-omx-rpi \
+#        --enable-mmal \            https://github.com/raspberrypi/userland/issues/630
+#        --enable-neon \
+#        --enable-shared \
+#        --disable-static \
+#        --disable-debug \
+#        --disable-doc \
+#        --disable-ffplay \
+#        --extra-cflags="-I/usr/local/include \
+#                        -I/opt/vc/include \
+#                        -I/opt/vc/include/IL" \
+#        --extra-ldflags="-Wl,-rpath-link,/opt/vc/lib \
+#                         -Wl,-rpath,/opt/vc/lib" && \
+#    make -j"$(nproc)" install && \
+#    cd / && \
+#    rm -rf ffmpeg-${FFMPEG_VERSION} && \
+#    apt-get purge --autoremove -y \
+#    cmake \
+#    git \
+#    gcc-arm* \
+#    g++-arm* \
+#    pkg-config
+
 # Install the Edge TPU runtime
 RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list && \
     wget -q -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \

--- a/watsor/main.py
+++ b/watsor/main.py
@@ -136,7 +136,7 @@ class _HTTPApplication(_BasicApp):
                                   methods=["GET"], endpoint="stream_video_mpegts"))
         self._url_map = Map(rules)
 
-        self._server = make_server('', self._config['http']['port'], self._dispatch_request, threaded=True)
+        self._server = make_server('0.0.0.0', self._config['http']['port'], self._dispatch_request, threaded=True)
 
         log = getLogger('werkzeug')
         log.setLevel(self._args.log_level)


### PR DESCRIPTION
This PR adds support for Raspberry Pi 3 and 4 with 32-bit OS.

The Docker image inherits device type Debian Balena base image that has the Raspbian package source added and Raspbian userland pre-installed. The latter facilitates the install of FFmpeg with hardware acceleration support (MMAL and OMX).

Note: the build of MMAL library currently [fails](https://github.com/raspberrypi/userland/issues/630) on 64-bit OS, thus FFmpeg hardware decoding ( `-c:v h264_mmal`) is possible only on 32-bit OS.
