### PR TITLE
Raspberry images improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ image:
 	docker build --tag watsor.pi4.base --file docker/Dockerfile.pi4.base .
 	docker build --tag watsor          --file docker/Dockerfile          .
 	docker build --tag watsor.gpu      --file docker/Dockerfile.gpu      .
-	docker build --tag watsor.pi3      --file docker/Dockerfile.pi3 .
-	docker build --tag watsor.pi4      --file docker/Dockerfile.pi4 .
+	docker build --tag watsor.pi3      --file docker/Dockerfile.pi3      .
+	docker build --tag watsor.pi4      --file docker/Dockerfile.pi4      .
 
 all: plugin test package

--- a/docker/Dockerfile.pi3
+++ b/docker/Dockerfile.pi3
@@ -11,7 +11,9 @@ RUN python3 -m pip install -r requirements.txt --no-deps && \
 
 RUN [ "cross-build-end" ]
 
-USER watsor
+# Enable udevd in the container to get rid of "Error in device opening" for the Coral USB Accelerator.
+# The container also need to be run privileged, so we leave the default root user.
+ENV UDEV=1
 
 WORKDIR /
 

--- a/docker/Dockerfile.pi4
+++ b/docker/Dockerfile.pi4
@@ -11,7 +11,9 @@ RUN python3 -m pip install -r requirements.txt --no-deps && \
 
 RUN [ "cross-build-end" ]
 
-USER watsor
+# Enable udevd in the container to get rid of "Error in device opening" for the Coral USB Accelerator.
+# The container also need to be run privileged, so we leave the default root user.
+ENV UDEV=1
 
 WORKDIR /
 

--- a/docker/Dockerfile.pi4.base
+++ b/docker/Dockerfile.pi4.base
@@ -1,4 +1,4 @@
-FROM balenalib/raspberrypi4-64-ubuntu:bionic AS base
+FROM balenalib/raspberrypi4-64-debian:buster
 
 RUN [ "cross-build-start" ]
 
@@ -40,7 +40,7 @@ RUN install_packages \
         shapely \
         werkzeug \
         paho-mqtt \
-        https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp36-cp36m-linux_aarch64.whl
+        https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_aarch64.whl
 
 # Build latest userland tools and FFmpeg with hardware acceleration support
 #RUN install_packages \

--- a/docker/Dockerfile.pi4.base
+++ b/docker/Dockerfile.pi4.base
@@ -20,17 +20,13 @@ RUN install_packages \
     ffmpeg \
     zlib1g-dev \
     libpng-dev libjpeg-dev \
-    libgeos-dev \
-    libswscale-dev \
-    libtbb2 libtbb-dev \
-    libopenblas-dev libatlas-base-dev libblas-dev \
-    liblapack-dev \
-    libprotobuf-dev
+    libgeos-dev
 
 # Install Python and dependencies
 RUN install_packages \
     python3-dev \
     python3-pip \
+    python3-opencv \
     python3-scipy && \
     python3 -m pip install --upgrade \
         pip \
@@ -45,64 +41,6 @@ RUN install_packages \
         werkzeug \
         paho-mqtt \
         https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp36-cp36m-linux_aarch64.whl
-
-# Build OpenCV from sources
-ENV OPENCV_VERSION="4.1.1"
-
-RUN install_packages \
-    cmake \
-    gfortran \
-    gcc-arm* \
-    protobuf-compiler \
-    pkg-config && \
-    wget -q https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip && \
-    unzip ${OPENCV_VERSION}.zip -d /opt && \
-    rm /${OPENCV_VERSION}.zip  && \
-    mv /opt/opencv-${OPENCV_VERSION} /opt/opencv && \
-    mkdir /opt/opencv/cmake_binary && \
-    cd /opt/opencv/cmake_binary && \
-    cmake \
-      -D ENABLE_NEON=OFF \
-      -D ENABLE_VFPV3=OFF \
-      -D WITH_OPENMP=ON \
-      -D WITH_TBB=ON -D BUILD_TBB=ON \
-      -D WITH_JPEG=ON -D BUILD_JPEG=ON \
-      -D WITH_PNG=ON -D BUILD_PNG=ON \
-      -D WITH_TIFF=OFF -D BUILD_TIFF=OFF \
-      -D WITH_OPENEXR=OFF \
-      -D WITH_IPP=OFF \
-      -D WITH_WEBP=OFF \
-      -D WITH_FFMPEG=OFF \
-      -D WITH_1394=OFF \
-      -D WITH_GTK=OFF \
-      -D WITH_OPENCL=OFF \
-      -D WITH_QT=OFF \
-      -D WITH_V4L=OFF \
-      -D WITH_JASPER=OFF \
-      -D BUILD_TESTS=OFF \
-      -D BUILD_PERF_TESTS=OFF \
-      -D BUILD_EXAMPLES=OFF \
-      -D BUILD_SHARED_LIBS=ON \
-      -D CMAKE_BUILD_TYPE=RELEASE \
-      -D OPENCV_EXTRA_EXE_LINKER_FLAGS=-latomic \
-      -D OPENCV_ENABLE_NONFREE=ON \
-      -D INSTALL_C_EXAMPLES=OFF \
-      -D INSTALL_PYTHON_EXAMPLES=OFF \
-      -D BUILD_NEW_PYTHON_SUPPORT=ON \
-      -D BUILD_opencv_python2=OFF \
-      -D BUILD_opencv_python3=ON \
-      -D BUILD_opencv_java=OFF \
-      -D OPENCV_GENERATE_PKGCONFIG=ON \
-      .. && \
-    make -j"$(nproc)" install && \
-    ldconfig && \
-    rm -r /opt/opencv && \
-    apt-get purge --autoremove -y \
-    cmake \
-    gfortran \
-    gcc-arm* \
-    protobuf-compiler \
-    pkg-config
 
 # Build latest userland tools and FFmpeg with hardware acceleration support
 #RUN install_packages \

--- a/watsor/filter/mask.py
+++ b/watsor/filter/mask.py
@@ -83,6 +83,6 @@ def contours_key(contour):
 
 def find_contours(alpha_channel):
     ret, thresh = cv2.threshold(255 - alpha_channel, 0, 255, cv2.THRESH_BINARY_INV)
-    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[-2:]
     contours.sort(key=contours_key)
     return contours

--- a/watsor/test/detect_stream.py
+++ b/watsor/test/detect_stream.py
@@ -84,7 +84,7 @@ class ShapeDetector(Work):
             # Convert to gray color and find contours
             gray_image = cv2.cvtColor(image_np, cv2.COLOR_BGR2GRAY)
             ret, thresh = cv2.threshold(gray_image, 100, 255, cv2.THRESH_BINARY)
-            contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[-2:]
 
             # Detect shape type and bounding box
             c, d = 0, 0


### PR DESCRIPTION
Enabled udevd in Raspberry containers to get rid of `Error in device opening` when working with the Coral USB Accelerator.
The container needs to be run privileged, so we leave the default root user.

To speed up the build of Raspberry Pi 4 image OpenCV there was downgraded to 3.2.

Raspberry Pi 4 image based changed to Debian Buster as FFmpeg there has OMX and V4L2 support.

