### PR TITLE
Hass.io addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ A `secrets.yaml` will be resolved first by looking in the same folder as the YAM
 
 ### HomeAssistant integration
 
-Watsor can communicate with [HomeAssistant](https://www.home-assistant.io/) via [MQTT](http://mqtt.org/) - "Internet of Things" connectivity protocol. Please refer to [demo project](https://github.com/asmirnou/watsor-haas) to examine the configuration files.
+The easiest way to get started is using Watsor [add-ons](https://github.com/asmirnou/watsor-hassio-addons) for Home Assistant.
+
+Watsor can communicate with [HomeAssistant](https://www.home-assistant.io/) via [MQTT](http://mqtt.org/) - "Internet of Things" connectivity protocol. Please refer to [demo project](https://github.com/asmirnou/watsor-ha-demo) to examine the configuration files.
 
 <details>
 <summary>To configure optional MQTT client add the following lines (expand the snippet):</summary>

--- a/docker/Dockerfile.pi3
+++ b/docker/Dockerfile.pi3
@@ -11,10 +11,6 @@ RUN python3 -m pip install -r requirements.txt --no-deps && \
 
 RUN [ "cross-build-end" ]
 
-# Enable udevd in the container to get rid of "Error in device opening" for the Coral USB Accelerator.
-# The container also need to be run privileged, so we leave the default root user.
-ENV UDEV=1
-
 WORKDIR /
 
 CMD ["python3", "-m", "watsor.main", \

--- a/docker/Dockerfile.pi3.base
+++ b/docker/Dockerfile.pi3.base
@@ -52,6 +52,12 @@ RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" >
         libedgetpu1-std \
         python3-edgetpu
 
+# Enable udevd in the container to get rid of "Error in device opening" for the Coral USB Accelerator.
+# The container also need to be run privileged, so we leave the default root user.
+ENV UDEV=1
+RUN echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a6e", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rules \
+    && echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rule
+
 # Cleanup and dedicated user
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && apt-get autoclean -y && \

--- a/docker/Dockerfile.pi4
+++ b/docker/Dockerfile.pi4
@@ -11,10 +11,6 @@ RUN python3 -m pip install -r requirements.txt --no-deps && \
 
 RUN [ "cross-build-end" ]
 
-# Enable udevd in the container to get rid of "Error in device opening" for the Coral USB Accelerator.
-# The container also need to be run privileged, so we leave the default root user.
-ENV UDEV=1
-
 WORKDIR /
 
 CMD ["python3", "-m", "watsor.main", \

--- a/docker/Dockerfile.pi4.base
+++ b/docker/Dockerfile.pi4.base
@@ -112,6 +112,12 @@ RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" >
         libedgetpu1-std \
         python3-edgetpu
 
+# Enable udevd in the container to get rid of "Error in device opening" for the Coral USB Accelerator.
+# The container also need to be run privileged, so we leave the default root user.
+ENV UDEV=1
+RUN echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a6e", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rules \
+    && echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rule
+
 # Cleanup and dedicated user
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && apt-get autoclean -y && \


### PR DESCRIPTION
Making Watsor an add-on for Hass.io allows the user to extend the functionality around Home Assistant.

The add-ons are part of another [repository](https://github.com/asmirnou/watsor-hassio-addons).