### PR TITLE
start work on upgrade to latest Nvidia tensorrt version

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS base
+FROM ubuntu:20.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TF_CPP_MIN_LOG_LEVEL=2
@@ -23,6 +23,7 @@ FROM base AS builder
 LABEL watsor.builder="watsor.base.builder"
 
 # Build Wheel archives for the requirements and dependencies
+# cpXX corresponds to the Python version, e.g. Python 3.8
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     python3-dev \
@@ -37,7 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         werkzeug \
         paho-mqtt \
         tensorflow \
-        https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp36-cp36m-linux_x86_64.whl
+        https://github.com/google-coral/pycoral/releases/download/v2.0.0/tflite_runtime-2.5.0.post1-cp38-cp38-linux_x86_64.whl
 
 #
 # Copy libraries to the final image

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -11,7 +11,11 @@ USER watsor
 
 WORKDIR /
 
-CMD ["python3", "-m", "watsor.main_for_gpu", \
-     "--log-path", "/var/log/watsor", \
-     "--config", "/etc/watsor/config.yaml", \
-     "--model-path", "/usr/share/watsor/model"]
+CMD ["tail", "-f", "/dev/null"]
+#CMD ["python3", "-m", "watsor.main_for_gpu", \
+#     "--log-path", "/var/log/watsor", \
+#     "--config", "/etc/watsor/config.yaml", \
+#     "--model-path", "/usr/share/watsor/model"]
+
+# for testing:
+#python3 -m watsor.main_for_gpu --log-path /var/log/watsor --config /etc/watsor/config.yaml --model-path /usr/share/watsor/model

--- a/docker/Dockerfile.gpu.base
+++ b/docker/Dockerfile.gpu.base
@@ -1,88 +1,116 @@
 FROM watsor.base AS base
 
 #
-# CUDA 11.1 base
+# CUDA 11.4.2 base
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/base/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubuntu2004/base/Dockerfile
 #
-RUN wget -q -O - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
-    echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
 
-ENV CUDA_VERSION 11.1.1
-LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
+ENV NVARCH x86_64
+ENV NVIDIA_REQUIRE_CUDA "cuda>=11.4 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 driver>=450"
+ENV NV_CUDA_CUDART_VERSION 11.4.108-1
+ENV NV_CUDA_COMPAT_PACKAGE cuda-compat-11-4
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg2 curl ca-certificates && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/${NVARCH}/7fa2af80.pub | apt-key add - && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/${NVARCH} /" > /etc/apt/sources.list.d/cuda.list && \
+    if [ ! -z ${NV_ML_REPO_ENABLED} ]; then echo "deb ${NV_ML_REPO_URL} /" > /etc/apt/sources.list.d/nvidia-ml.list; fi && \
+    apt-get purge --autoremove -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CUDA_VERSION 11.4.2
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-cudart-11-1=11.1.74-1 \
-    cuda-compat-11-1 \
-    cuda-cupti-11-1 \
-    && ln -s cuda-11.1 /usr/local/cuda && \
+    cuda-cudart-11-4=${NV_CUDA_CUDART_VERSION} \
+    ${NV_CUDA_COMPAT_PACKAGE} \
+    && ln -s cuda-11.4 /usr/local/cuda && \
     rm -rf /var/lib/apt/lists/*
 
 # Required for nvidia-docker v1
-RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
-    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf \
-    # Required for TensroFlow 2.4.0 to load GPU
-    && ln -s /usr/local/cuda/lib64/libcusolver.so.11 /usr/local/cuda/lib64/libcusolver.so.10
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+    && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:${LD_LIBRARY_PATH}
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,video,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=11.1 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 brand=tesla,driver>=450,driver<451"
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
 
 #
-# CUDA 11.1 runtime
+# CUDA 11.4.2 runtime
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/runtime/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubuntu2004/runtime/Dockerfile
 #
-ENV NCCL_VERSION 2.7.8
+
+ENV NV_CUDA_LIB_VERSION 11.4.2-1
+
+ENV NV_NVTX_VERSION 11.4.120-1
+ENV NV_LIBNPP_VERSION 11.4.0.110-1
+ENV NV_LIBNPP_PACKAGE libnpp-11-4=${NV_LIBNPP_VERSION}
+ENV NV_LIBCUSPARSE_VERSION 11.6.0.120-1
+
+ENV NV_LIBCUBLAS_PACKAGE_NAME libcublas-11-4
+ENV NV_LIBCUBLAS_VERSION 11.6.1.51-1
+ENV NV_LIBCUBLAS_PACKAGE ${NV_LIBCUBLAS_PACKAGE_NAME}=${NV_LIBCUBLAS_VERSION}
+
+ENV NV_LIBNCCL_PACKAGE_NAME libnccl2
+ENV NV_LIBNCCL_PACKAGE_VERSION 2.11.4-1
+ENV NCCL_VERSION 2.11.4-1
+ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}=${NV_LIBNCCL_PACKAGE_VERSION}+cuda11.4
+
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-libraries-11-1=11.1.1-1 \
-    libnpp-11-1=11.1.2.301-1 \
-    cuda-nvtx-11-1=11.1.74-1 \
-    libcublas-11-1=11.3.0.106-1 \
-    libnccl2=$NCCL_VERSION-1+cuda11.1 \
-    && apt-mark hold libnccl2 \
+    cuda-libraries-11-4=${NV_CUDA_LIB_VERSION} \
+    ${NV_LIBNPP_PACKAGE} \
+    cuda-nvtx-11-4=${NV_NVTX_VERSION} \
+    libcusparse-11-4=${NV_LIBCUSPARSE_VERSION} \
+    ${NV_LIBCUBLAS_PACKAGE} \
+    ${NV_LIBNCCL_PACKAGE} \
     && rm -rf /var/lib/apt/lists/*
 
-#
-# cuDNN 8.0.5.39 runtime
-#
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/runtime/cudnn8/Dockerfile
-#
-ENV CUDNN_VERSION 8.0.5.39
+# Keep apt from auto upgrading the cublas and nccl packages. See https://gitlab.com/nvidia/container-images/cuda/-/issues/88
+RUN apt-mark hold ${NV_LIBCUBLAS_PACKAGE_NAME} ${NV_LIBNCCL_PACKAGE_NAME}
 
-LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
+
+#
+# cuDNN 8.2.4.15 runtime
+#
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubuntu2004/runtime/cudnn8/Dockerfile
+#
+ENV NV_CUDNN_VERSION 8.2.4.15
+
+ENV NV_CUDNN_PACKAGE "libcudnn8=$NV_CUDNN_VERSION-1+cuda11.4"
+ENV NV_CUDNN_PACKAGE_NAME "libcudnn8"
+
+LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libcudnn8=$CUDNN_VERSION-1+cuda11.1 \
-    && apt-mark hold libcudnn8 && \
+    ${NV_CUDNN_PACKAGE} \
+    && apt-mark hold ${NV_CUDNN_PACKAGE_NAME} && \
     rm -rf /var/lib/apt/lists/*
 
 #
-# TensorRT 7.2.2
+# TensorRT 8.2.0
 #
-# https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-722/install-guide/index.html#maclearn-net-repo-install-rpm
+# https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#maclearn-net-repo-install
 #
-ENV TENSORRT_VERSION 7.2.2
+ENV TENSORRT_VERSION 8.2.0
 LABEL com.nvidia.tensorrt.version="${TENSORRT_VERSION}"
 
-RUN version=$TENSORRT_VERSION-1+cuda11.1 && \
+RUN version=$TENSORRT_VERSION-1+cuda11.4 && \
     apt-get update && apt-get install -y --no-install-recommends \
-    libnvinfer7=${version} \
-    libnvonnxparsers7=${version} libnvparsers7=${version} \
-    libnvinfer-plugin7=${version} \
+    libnvinfer8=${version} \
+    libnvonnxparsers8=${version} libnvparsers8=${version} \
+    libnvinfer-plugin8=${version} \
     python3-libnvinfer=${version} \
     && apt-mark hold \
-    libnvinfer7 \
-    libnvonnxparsers7 libnvparsers7 \
-    libnvinfer-plugin7 \
+    libnvinfer8 \
+    libnvonnxparsers8 libnvparsers8 \
+    libnvinfer-plugin8 \
     python3-libnvinfer \
     && rm -rf /var/lib/apt/lists/*
 
@@ -100,23 +128,43 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 #
-# CUDA 11.1 devel
+# CUDA 11.4.2 devel
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/devel/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.2/ubuntu2004/devel/Dockerfile
 #
+
+ENV NV_CUDA_CUDART_DEV_VERSION 11.4.108-1
+ENV NV_NVML_DEV_VERSION 11.4.120-1
+ENV NV_LIBCUSPARSE_DEV_VERSION 11.6.0.120-1
+ENV NV_LIBNPP_DEV_VERSION 11.4.0.110-1
+ENV NV_LIBNPP_DEV_PACKAGE libnpp-dev-11-4=${NV_LIBNPP_DEV_VERSION}
+
+ENV NV_LIBCUBLAS_DEV_PACKAGE_NAME libcublas-dev-11-4
+ENV NV_LIBCUBLAS_DEV_VERSION 11.6.1.51-1
+ENV NV_LIBCUBLAS_DEV_PACKAGE ${NV_LIBCUBLAS_DEV_PACKAGE_NAME}=${NV_LIBCUBLAS_DEV_VERSION}
+
+ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-dev
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.11.4-1
+ENV NCCL_VERSION 2.11.4-1
+ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}=${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda11.4
+
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-nvml-dev-11-1=11.1.74-1 \
-    cuda-command-line-tools-11-1=11.1.1-1 \
-    cuda-nvprof-11-1=11.1.105-1 \
-    libnpp-dev-11-1=11.1.2.301-1 \
-    cuda-libraries-dev-11-1=11.1.1-1 \
-    cuda-minimal-build-11-1=11.1.1-1 \
-    libnccl-dev=2.7.8-1+cuda11.1 \
-    libcublas-dev-11-1=11.3.0.106-1 \
-    libcusparse-11-1=11.3.0.10-1 \
-    libcusparse-dev-11-1=11.3.0.10-1 \
-    && apt-mark hold libnccl-dev \
+    libtinfo5 libncursesw5 \
+    cuda-cudart-dev-11-4=${NV_CUDA_CUDART_DEV_VERSION} \
+    cuda-command-line-tools-11-4=${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-11-4=${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-dev-11-4=${NV_CUDA_LIB_VERSION} \
+    cuda-nvml-dev-11-4=${NV_NVML_DEV_VERSION} \
+    ${NV_LIBNPP_DEV_PACKAGE} \
+    libcusparse-dev-11-4=${NV_LIBCUSPARSE_DEV_VERSION} \
+    ${NV_LIBCUBLAS_DEV_PACKAGE} \
+    ${NV_LIBNCCL_DEV_PACKAGE} \
     && rm -rf /var/lib/apt/lists/*
+
+# Keep apt from auto upgrading the cublas and nccl packages. See https://gitlab.com/nvidia/container-images/cuda/-/issues/88
+RUN apt-mark hold ${NV_LIBCUBLAS_DEV_PACKAGE_NAME} ${NV_LIBNCCL_DEV_PACKAGE_NAME}
+
 
 # Install PyCUDA
 RUN python3 -m pip install pycuda \

--- a/watsor/engine.py
+++ b/watsor/engine.py
@@ -18,7 +18,8 @@ def build_engine(uff_model_path, trt_engine_datatype=trt.DataType.FLOAT,
     with trt.Builder(TRT_LOGGER) as builder, \
             builder.create_network() as network, \
             trt.UffParser() as uff_parser:
-        builder.max_workspace_size = 1 << 30
+        config = builder.create_builder_config()
+        config.max_workspace_size = 1 << 30
         builder.max_batch_size = batch_size
         if trt_engine_datatype == trt.DataType.HALF:
             builder.fp16_mode = True
@@ -27,7 +28,7 @@ def build_engine(uff_model_path, trt_engine_datatype=trt.DataType.FLOAT,
         uff_parser.register_output("MarkOutput_0")
         uff_parser.parse(uff_model_path, network)
 
-        return builder.build_cuda_engine(network)
+        return builder.build_serialized_network(network, config)
 
 
 def save_engine(engine, engine_dest_path):


### PR DESCRIPTION
This isn't finished but it's a start at upgrading to a new tensorrt version.  It uses a newer Ubuntu LTS version and much of it is a direct copy-paste from the code in the Github repo from Nvidia.  `watsor/engine.py` needs some work as there are likely additional code changes to make in order to build with this new version.  I hope it's helpful to someone as a starting point.  I don't have experience with tensorrt so I thought others might be able to run with it.