### PR TITLE
Tensorrt 8 support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2020 Alexander Smirnov
+Copyright (c) 2023 Alexander Smirnov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ Watsor uses convolutional neural network trained to recognize 90 classes of obje
 
 The models are available in several formats depending on the device the inference is being performed on.
  - If you've got [The Coral USB Accelerator](https://coral.ai/products/accelerator/) download one of the models built for Edge TPU (MobileNet v1/v2), rename the file and put in `model/` folder as `edgetpu.tflite`. 
- - Have [Nvidia CUDA GPU](https://developer.nvidia.com/cuda-gpus) on board - download one of the models, rename the file and put in `model/` folder as `gpu.uff`.
- - CPU is used only when there are no accelerators or their models provided. Inside of TensorFlow archive you will find several files, you only need `frozen_inference_graph.pb` renamed as `cpu.pb` and placed in the `model/` folder. New models do not have frozen graph, but there is a `saved_model` folder that needs to be copied in full to the `model/` folder of Watsor. 
+ - Have [Nvidia CUDA GPU](https://developer.nvidia.com/cuda-gpus) on board - download one of the models, rename the file and put in `model/` folder as `gpu.uff`. Watsor also works with TF2 models in ONNX format, these you need to convert yourself using [the following guide](https://github.com/NVIDIA/TensorRT/tree/8.5.3/samples/python/tensorflow_object_detection_api#create-onnx-graph), then save as `model/gpu.onnx`.
+ - CPU is used only when there are no accelerators or their models provided. Inside of TensorFlow archive you will find several files, you only need `frozen_inference_graph.pb` renamed as `cpu.pb` and placed in the `model/` folder. TF2 models do not have frozen graph, but there is a `saved_model` folder that needs to be copied in full to the `model/` folder of Watsor. 
  
     <sub>Please note that _saved model_ takes longer to start. If TensorFlow is configured properly, GPU will be involved.</sub>
  - For single board computer such as Raspberry Pi or [Jetson Nano](https://github.com/asmirnou/watsor/wiki/Deploying-Watsor-to-Jetson-Nano) lightweight model is more efficient. Download and unpack if needed, rename the file and put in `model/` folder as `cpu.tflite`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Watsor detects objects in video stream using deep learning-based approach. Inten
     + [Detection classes and filters](#detection-classes-and-filters)
     + [Zones and masks](#zones-and-masks)
     + [Tips](#tips)
-    + [Environmental variables](#environmental-variables)
+    + [Environment variables](#environment-variables)
     + [Secrets](#secrets)
     + [HomeAssistant integration](#homeassistant-integration)
   * [Running Watsor](#running-watsor)
@@ -242,9 +242,9 @@ python3 -m watsor.zones -m config/porch.png
     
     First the rate is lowered even more down to 10 FPS in order to guarantee constant feed for FFmpeg encoder (`-r 10`). The frames exceeding 10 FPS are dropped (`-vsync drop`) in order to match the target rate. Then output speed is set to be standard `30000/1001` (~30 FPS) and constant (`-vsync cfr`) to produce fluent video stream, duplicating frames as necessary to achieve the targeted output frame rate.
 
-### Environmental variables
+### Environment variables
  
-You can include values from your system’s environment variables either like [Home Assistant Core does](https://www.home-assistant.io/docs/configuration/yaml/#environmental-variables):
+You can include values from your system’s environment variables either like [Home Assistant Core does](https://www.home-assistant.io/docs/configuration/yaml/#environment-variables):
  
  `password: !env_var PASSWORD default_password` or 
  
@@ -462,10 +462,10 @@ If you've got the Coral install the [Edge TPU runtime](https://coral.ai/docs/acc
 
 Have [Nvidia CUDA GPU](https://developer.nvidia.com/cuda-gpus) on board - install the following components (now the hard part, you'd better consider [Docker](#docker):
 - [NVIDIA® GPU drivers](https://www.nvidia.com/drivers) for your graphic card
-- [CUDA® 11.1.1](https://docs.nvidia.com/cuda/archive/11.1.1/#installation-guides)
-- [cuDNN 8.0.5](https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-805/install-guide/index.html)
-- [TensorRT 7.2.2](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-722/install-guide/index.html)
-- [PyCUDA 2020.1](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-722/install-guide/index.html#installing-pycuda)
+- [CUDA® 11.8.0](https://docs.nvidia.com/cuda/archive/11.8.0/#installation-guides)
+- [cuDNN 8.9.0](https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-890/install-guide/index.html)
+- [TensorRT 8.5.3](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-853/install-guide/index.html)
+- [PyCUDA 2022.2.2](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-853/install-guide/index.html#installing-pycuda)
 
 ## Building from source
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS base
+FROM ubuntu:20.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TF_CPP_MIN_LOG_LEVEL=2
@@ -30,14 +30,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && python3 -m pip wheel --wheel-dir=/tmp/install \
         PyYaml \
         cerberus \
-        numpy \
+        numpy==1.23.* \
         scipy \
         opencv-python-headless \
         shapely \
         werkzeug \
         paho-mqtt \
         tensorflow \
-        https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp36-cp36m-linux_x86_64.whl
+        https://github.com/google-coral/pycoral/releases/download/v2.0.0/tflite_runtime-2.5.0.post1-cp38-cp38-linux_x86_64.whl
 
 #
 # Copy libraries to the final image

--- a/docker/Dockerfile.gpu.base
+++ b/docker/Dockerfile.gpu.base
@@ -1,88 +1,83 @@
 FROM watsor.base AS base
 
 #
-# CUDA 11.1 base
+# CUDA 11.8.0 base
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/base/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubuntu2004/base/Dockerfile
 #
-RUN wget -q -O - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
-    echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+RUN wget -q -O - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub | apt-key add - && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" > /etc/apt/sources.list.d/cuda.list
 
-ENV CUDA_VERSION 11.1.1
+ENV CUDA_VERSION 11.8.0
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-cudart-11-1=11.1.74-1 \
-    cuda-compat-11-1 \
-    cuda-cupti-11-1 \
-    && ln -s cuda-11.1 /usr/local/cuda && \
-    rm -rf /var/lib/apt/lists/*
+    cuda-cudart-11-8=11.8.89-1 \
+    cuda-compat-11-8 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Required for nvidia-docker v1
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
-    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf \
-    # Required for TensroFlow 2.4.0 to load GPU
-    && ln -s /usr/local/cuda/lib64/libcusolver.so.11 /usr/local/cuda/lib64/libcusolver.so.10
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:${LD_LIBRARY_PATH}
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,video,utility
-ENV NVIDIA_REQUIRE_CUDA "cuda>=11.1 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 brand=tesla,driver>=450,driver<451"
+ENV NVIDIA_REQUIRE_CUDA "cuda>=11.8 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471"
 
 #
-# CUDA 11.1 runtime
+# CUDA 11.8 runtime
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/runtime/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubuntu2004/runtime/Dockerfile
 #
-ENV NCCL_VERSION 2.7.8
+ENV NCCL_VERSION 2.16.2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-libraries-11-1=11.1.1-1 \
-    libnpp-11-1=11.1.2.301-1 \
-    cuda-nvtx-11-1=11.1.74-1 \
-    libcublas-11-1=11.3.0.106-1 \
-    libnccl2=$NCCL_VERSION-1+cuda11.1 \
-    && apt-mark hold libnccl2 \
+    cuda-libraries-11-8=11.8.0-1 \
+    libnpp-11-8=11.8.0.86-1 \
+    cuda-nvtx-11-8=11.8.86-1 \
+    libcublas-11-8=11.11.3.6-1 \
+    libcusparse-11-8=11.7.5.86-1 \
+    libnccl2=$NCCL_VERSION-1+cuda11.8 \
+    && apt-mark hold libcublas-11-8 libnccl2 \
     && rm -rf /var/lib/apt/lists/*
 
 #
-# cuDNN 8.0.5.39 runtime
+# cuDNN 8.9.0.131 runtime
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/runtime/cudnn8/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubuntu2004/runtime/cudnn8/Dockerfile
 #
-ENV CUDNN_VERSION 8.0.5.39
+ENV CUDNN_VERSION 8.9.0.131
 
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libcudnn8=$CUDNN_VERSION-1+cuda11.1 \
-    && apt-mark hold libcudnn8 && \
-    rm -rf /var/lib/apt/lists/*
+    libcudnn8=$CUDNN_VERSION-1+cuda11.8 \
+    && apt-mark hold libcudnn8 \
+    && rm -rf /var/lib/apt/lists/*
 
 #
-# TensorRT 7.2.2
+# TensorRT 8.5.3
 #
-# https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-722/install-guide/index.html#maclearn-net-repo-install-rpm
+# https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-853/install-guide/index.html#installing-rpm
 #
-ENV TENSORRT_VERSION 7.2.2
+ENV TENSORRT_VERSION 8.5.3
 LABEL com.nvidia.tensorrt.version="${TENSORRT_VERSION}"
 
-RUN version=$TENSORRT_VERSION-1+cuda11.1 && \
+RUN version=$TENSORRT_VERSION-1+cuda11.8 && \
     apt-get update && apt-get install -y --no-install-recommends \
-    libnvinfer7=${version} \
-    libnvonnxparsers7=${version} libnvparsers7=${version} \
-    libnvinfer-plugin7=${version} \
+    libnvinfer8=${version} \
+    libnvonnxparsers8=${version} libnvparsers8=${version} \
+    libnvinfer-plugin8=${version} \
     python3-libnvinfer=${version} \
     && apt-mark hold \
-    libnvinfer7 \
-    libnvonnxparsers7 libnvparsers7 \
-    libnvinfer-plugin7 \
+    libnvinfer8 \
+    libnvonnxparsers8 libnvparsers8 \
+    libnvinfer-plugin8 \
     python3-libnvinfer \
     && rm -rf /var/lib/apt/lists/*
 
@@ -100,22 +95,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 #
-# CUDA 11.1 devel
+# CUDA 11.8 devel
 #
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1/ubuntu18.04-x86_64/devel/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubuntu2004/devel/Dockerfile
 #
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cuda-nvml-dev-11-1=11.1.74-1 \
-    cuda-command-line-tools-11-1=11.1.1-1 \
-    cuda-nvprof-11-1=11.1.105-1 \
-    libnpp-dev-11-1=11.1.2.301-1 \
-    cuda-libraries-dev-11-1=11.1.1-1 \
-    cuda-minimal-build-11-1=11.1.1-1 \
-    libnccl-dev=2.7.8-1+cuda11.1 \
-    libcublas-dev-11-1=11.3.0.106-1 \
-    libcusparse-11-1=11.3.0.10-1 \
-    libcusparse-dev-11-1=11.3.0.10-1 \
-    && apt-mark hold libnccl-dev \
+    libtinfo5 libncursesw5 \
+    cuda-cudart-dev-11-8=11.8.89-1 \
+    cuda-command-line-tools-11-8=11.8.0-1 \
+    cuda-minimal-build-11-8=11.8.0-1 \
+    cuda-libraries-dev-11-8=11.8.0-1 \
+    cuda-nvml-dev-11-8=11.8.86-1 \
+    cuda-nvprof-11-8=11.8.87-1 \
+    libnpp-dev-11-8=11.8.0.86-1 \
+    libcusparse-dev-11-8=11.7.5.86-1 \
+    libcublas-dev-11-8=11.11.3.6-1 \
+    libnccl-dev=2.16.2-1+cuda11.8 \
+    && apt-mark hold libcublas-dev-11-8 libnccl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PyCUDA
@@ -138,3 +134,5 @@ RUN mkdir model && \
     mv model/gpu.uff /usr/share/watsor/model && \
     chown watsor:watsor /usr/share/watsor/model/gpu.uff && \
     rm -r model
+
+ENV CUDA_MODULE_LOADING=LAZY

--- a/docker/Dockerfile.jetson.base
+++ b/docker/Dockerfile.jetson.base
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/l4t-base:r32.4.4 AS base
+FROM nvcr.io/nvidia/l4t-base:r32.7.1 AS base
 
 # Install basic packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         paho-mqtt \
         pycuda \
         six \
-        https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp36-cp36m-linux_aarch64.whl
+        https://github.com/google-coral/pycoral/releases/download/v2.0.0/tflite_runtime-2.5.0.post1-cp36-cp36m-linux_aarch64.whl
 
 #
 # Copy libraries to the final image
@@ -91,3 +91,4 @@ RUN mkdir model \
 EXPOSE 8080
 
 ENV TRT_FLOAT_PRECISION=16
+ENV CUDA_MODULE_LOADING=LAZY

--- a/docker/Dockerfile.jetson.base
+++ b/docker/Dockerfile.jetson.base
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/l4t-base:r32.7.1 AS base
+FROM nvcr.io/nvidia/l4t-tensorrt:r8.5.2-runtime AS base
 
 # Install basic packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
     gnupg2 \
-    libgeos-c1v5 libgeos-3.6.2 \
     python3-pip \
     && python3 -m pip install --upgrade \
         pip \
@@ -15,9 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 #
-# Use the previous stage as a new temporary stage for building libraries
+# Use another image with CUDA headers as a new temporary stage for building libraries
 #
-FROM base AS builder
+FROM nvcr.io/nvidia/l4t-tensorrt:r8.5.2.2-devel AS builder
 
 LABEL watsor.builder="watsor.jetson.base.builder"
 
@@ -27,12 +26,17 @@ ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/targets/aarch64-linux/lib
 
 # Build Wheel archives for the requirements and dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     build-essential \
+    python3-pip \
     python3-dev \
-    libgeos-dev \
+    && python3 -m pip install --upgrade \
+        pip \
+        setuptools \
+        wheel \
     && rm -rf /var/lib/apt/lists/* \
     && python3 -m pip wheel --wheel-dir=/tmp/install \
-        numpy==1.19.4 \
+        numpy \
         scipy \
         opencv-python-headless \
         PyYaml \
@@ -42,7 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         paho-mqtt \
         pycuda \
         six \
-        https://github.com/google-coral/pycoral/releases/download/v2.0.0/tflite_runtime-2.5.0.post1-cp36-cp36m-linux_aarch64.whl
+        https://github.com/google-coral/pycoral/releases/download/v2.0.0/tflite_runtime-2.5.0.post1-cp38-cp38-linux_aarch64.whl
 
 #
 # Copy libraries to the final image

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except FileNotFoundError:
     result = None
 version = result.stdout.splitlines()[0] \
-    if result is not None and result.returncode == 0 and len(result.stdout) > 0 else 'dev'
+    if result is not None and result.returncode == 0 and len(result.stdout) > 0 else '0.0.0'
 
 setup(
     name="watsor",

--- a/watsor/detection/detector.py
+++ b/watsor/detection/detector.py
@@ -41,7 +41,7 @@ def create_object_detectors(delegate_class, stop_event, log_queue, frame_queue, 
         for device, clazz in edge_tpus():
             append_detector(clazz, device)
 
-    if path.isfile(path.join(model_path, 'gpu.buf')):
+    if path.isfile(path.join(model_path, 'gpu.trt')):
         for device, clazz in cuda_gpus():
             append_detector(clazz, device)
 

--- a/watsor/detection/tensorrt_gpu.py
+++ b/watsor/detection/tensorrt_gpu.py
@@ -11,8 +11,6 @@ from typing import List
 from time import time
 from watsor.stream.share import Detection
 
-HostDeviceMem = namedtuple('HostDeviceMem', 'host device')
-
 
 class TensorRTObjectDetector:
     """Performs object detection on Nvidia CUDA GPUs.
@@ -22,25 +20,35 @@ class TensorRTObjectDetector:
     def __init__(self, model_path, device):
         cuda.init()
         self.__device = cuda.Device(device)
-        self.context = self.__device.make_context()
+        self.__context = self.__device.make_context()
 
         trt.init_libnvinfer_plugins(engine.TRT_LOGGER, '')
 
         self.__trt_runtime = trt.Runtime(engine.TRT_LOGGER)
         try:
-            self.__trt_engine = engine.load_engine(self.__trt_runtime, os.path.join(model_path, 'gpu.trt'))
+            trt_engine = engine.load_engine(self.__trt_runtime, os.path.join(model_path, 'gpu.trt'))
         except Exception as e:
             self.__finalize()
             raise e
 
-        self._allocate_buffers()
+        self.__inference = _Inference.from_engine(trt_engine)
 
-        self.__model_shape = itemgetter(1, 2)(self.__trt_engine.get_binding_shape('Input'))
-        self.__execution_context = self.__trt_engine.create_execution_context()
+        input_shape = trt_engine.get_binding_shape(self.__inference.input_tensor_index)
+        if len(input_shape) == 4:
+            input_shape = input_shape[1:]
+
+        if input_shape[0] == 3:
+            self.__transpose = True
+            self.__model_shape = itemgetter(1, 2)(input_shape)  # NCHW
+        elif input_shape[2] == 3:
+            self.__transpose = False
+            self.__model_shape = itemgetter(0, 1)(input_shape)  # NHWC
+
+        assert self.__model_shape, "Invalid input tensor share"
 
     def __finalize(self):
-        self.context.pop()
-        self.context = None
+        self.__context.pop()
+        self.__context = None
 
         clear_context_caches()
 
@@ -57,68 +65,134 @@ class TensorRTObjectDetector:
     def detect(self, image_shape, image_np, detections: List[Detection]):
         # Resize to model shape
         image_tensor = cv2.resize(image_np, dsize=self.__model_shape, interpolation=cv2.INTER_LINEAR)
-        # HWC -> CHW
-        image_tensor = image_tensor.transpose((2, 0, 1))
-        # Normalize to [-1.0, 1.0] interval (expected by model)
-        image_tensor = (2.0 / 255.0) * image_tensor - 1.0
-        image_tensor = image_tensor.ravel()
+        if self.__transpose:
+            image_tensor = image_tensor.transpose((2, 0, 1))  # HWC -> CHW
 
-        np.copyto(self.inputs[0].host, image_tensor)
         inference_start_time = time()
-        detection_out, keep_count_out = self._do_inference()
+        boxes, classes, scores = self.__inference.detect(image_tensor)
         inference_time = (time() - inference_start_time) * 1000
+
+        if self.__transpose:
+            boxes = boxes[:, [1, 0, 3, 2]]
 
         d = 0
         max_width = image_shape[1] - 1
         max_height = image_shape[0] - 1
-        while d < int(keep_count_out[0]) and d < len(detections):
+        while d < len(scores) and d < len(detections):
             detection = detections[d]
-            pred_start_idx = d * 7
-            detection.label = detection_out[pred_start_idx + 1]
-            detection.confidence = detection_out[pred_start_idx + 2]
-            detection.bounding_box.x_min = int(detection_out[pred_start_idx + 3] * max_width)
-            detection.bounding_box.y_min = int(detection_out[pred_start_idx + 4] * max_height)
-            detection.bounding_box.x_max = int(detection_out[pred_start_idx + 5] * max_width)
-            detection.bounding_box.y_max = int(detection_out[pred_start_idx + 6] * max_height)
+            detection.label = classes[d]
+            detection.confidence = scores[d]
+            detection.bounding_box.y_min = min(int(boxes[d][0] * max_height), max_height)
+            detection.bounding_box.x_min = min(int(boxes[d][1] * max_width), max_width)
+            detection.bounding_box.y_max = min(int(boxes[d][2] * max_height), max_height)
+            detection.bounding_box.x_max = min(int(boxes[d][3] * max_width), max_width)
             d += 1
 
         return inference_time
 
-    def _do_inference(self):
-        [cuda.memcpy_htod_async(inp.device, inp.host, self.stream) for inp in self.inputs]
-        self.__execution_context.execute_async(batch_size=self.__trt_engine.max_batch_size,
-                                               bindings=self.bindings,
-                                               stream_handle=self.stream.handle)
-        [cuda.memcpy_dtoh_async(out.host, out.device, self.stream) for out in self.outputs]
-        self.stream.synchronize()
-        return [out.host for out in self.outputs]
 
-    def _allocate_buffers(self):
-        self.inputs = []
-        self.outputs = []
-        self.bindings = []
-        self.stream = cuda.Stream()
+_Binding = namedtuple('Binding', 'index name dtype shape allocation')
 
-        # NMS implementation in TRT 6 only supports DataType.FLOAT
-        binding_to_type = {"Input": np.float32,
-                           "NMS": np.float32,
-                           "NMS_1": np.int32,
-                           "Postprocessor": np.float32,
-                           "Postprocessor_1": np.int32}
-        for binding in self.__trt_engine:
-            shape = self.__trt_engine.get_binding_shape(binding)
-            size = trt.volume(shape) * self.__trt_engine.max_batch_size
-            dtype = binding_to_type[str(binding)]
+
+class _Inference(object):
+
+    def __init__(self, trt_engine, input_tensor_index):
+        self.__input_tensor_index = input_tensor_index
+        self.__allocate_buffers(trt_engine)
+        self._execution_context = trt_engine.create_execution_context()
+        self.__stream = cuda.Stream()
+
+    @property
+    def input_tensor_index(self):
+        return self.__input_tensor_index
+
+    def detect(self, image_tensor):
+        return [], [], []
+
+    def __allocate_buffers(self, trt_engine):
+        self.__inputs = []
+        self.__outputs = []
+        self.__bindings = []
+
+        for idx, binding in enumerate(trt_engine):
+            shape = trt_engine.get_binding_shape(binding)
+            dtype = trt_engine.get_binding_dtype(binding)
+            dtype = self._override_binding_type(binding, dtype)
+            dtype_class = np.dtype(trt.nptype(dtype))
 
             # Allocate host and device buffers
-            host_mem = cuda.pagelocked_empty(size, dtype)
-            device_mem = cuda.mem_alloc(host_mem.nbytes)
+            size = trt.volume(shape) * dtype_class.itemsize
+            allocation = cuda.mem_alloc(size)
+
+            binding_tuple = _Binding(idx, str(binding), dtype_class, list(shape), allocation)
 
             # Append the device buffer to device bindings.
-            self.bindings.append(int(device_mem))
+            self.__bindings.append(allocation)
 
             # Append to the appropriate list.
-            if self.__trt_engine.binding_is_input(binding):
-                self.inputs.append(HostDeviceMem(host_mem, device_mem))
+            if trt_engine.binding_is_input(binding):
+                self.__inputs.append(binding_tuple)
             else:
-                self.outputs.append(HostDeviceMem(host_mem, device_mem))
+                self.__outputs.append(binding_tuple)
+
+        assert len(self.__inputs) > 0
+        assert len(self.__outputs) > 0
+        assert len(self.__bindings) > 0
+
+    def _override_binding_type(self, binding: str, dtype):
+        return dtype
+
+    def _do_inference(self, image_tensor, func):
+        tensor_binding = self.__inputs[self.input_tensor_index]
+        host_mem = np.ascontiguousarray(image_tensor.astype(dtype=tensor_binding.dtype))
+        cuda.memcpy_htod_async(tensor_binding.allocation, host_mem, self.__stream)
+
+        func(bindings=self.__bindings, stream_handle=self.__stream.handle)
+
+        outputs = []
+        for binding_tuple in self.__outputs:
+            output = np.zeros(binding_tuple.shape, binding_tuple.dtype)
+            cuda.memcpy_dtoh_async(output, binding_tuple.allocation, self.__stream)
+            outputs.append(output)
+
+        self.__stream.synchronize()
+
+        return outputs
+
+    @classmethod
+    def from_engine(cls, trt_engine):
+        bindings = dict((name, idx) for idx, name in enumerate(trt_engine))
+        input_tensor_index = bindings.get('Input')
+        if input_tensor_index is None:
+            input_tensor_index = bindings.get('input_tensor')
+            if input_tensor_index is None:
+                assert False, "No input tensor found"
+            else:
+                return _InferenceONNX(trt_engine, input_tensor_index)
+        else:
+            return _InferenceUFF(trt_engine, input_tensor_index)
+
+
+class _InferenceUFF(_Inference):
+
+    def detect(self, image_tensor):
+        # Normalize to [-1.0, 1.0] interval (expected by model)
+        image_tensor = (2.0 / 255.0) * image_tensor - 1.0
+
+        detections, _ = self._do_inference(image_tensor, self._execution_context.execute_async)
+
+        classes = detections[0][:, 1].astype(dtype=np.int32)
+        scores = detections[0][:, 2]
+        boxes = detections[0][:, 3:7]
+
+        return boxes, classes, scores
+
+    def _override_binding_type(self, binding, dtype):
+        return trt.int32 if str(binding).endswith("_1") else dtype
+
+
+class _InferenceONNX(_Inference):
+
+    def detect(self, image_tensor):
+        _, boxes, scores, classes = self._do_inference(image_tensor, self._execution_context.execute_async_v2)
+        return boxes[0], classes[0] + 1, scores[0]

--- a/watsor/detection/tensorrt_gpu.py
+++ b/watsor/detection/tensorrt_gpu.py
@@ -28,7 +28,7 @@ class TensorRTObjectDetector:
 
         self.__trt_runtime = trt.Runtime(engine.TRT_LOGGER)
         try:
-            self.__trt_engine = engine.load_engine(self.__trt_runtime, os.path.join(model_path, 'gpu.buf'))
+            self.__trt_engine = engine.load_engine(self.__trt_runtime, os.path.join(model_path, 'gpu.trt'))
         except Exception as e:
             self.__finalize()
             raise e

--- a/watsor/engine.py
+++ b/watsor/engine.py
@@ -11,23 +11,32 @@ except ImportError as e:
         exit()
 
 TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
+TRT_MAIN_VERSION = int(trt.__version__[0])
 
 
-def build_engine(uff_model_path, trt_engine_datatype=trt.DataType.FLOAT,
-                 batch_size=1, model_width=300, model_height=300):
+def build_engine(uff_model_path, trt_engine_datatype, batch_size, workspace, model_width, model_height):
     with trt.Builder(TRT_LOGGER) as builder, \
             builder.create_network() as network, \
-            trt.UffParser() as uff_parser:
-        builder.max_workspace_size = 1 << 30
-        builder.max_batch_size = batch_size
+            builder.create_builder_config() as config, \
+            trt.UffParser() as uff_parser, \
+            trt.Runtime(TRT_LOGGER) as runtime:
+        if TRT_MAIN_VERSION < 8:
+            config.max_workspace_size = workspace * (1 << 20)
+        else:
+            config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace * (1 << 20))
         if trt_engine_datatype == trt.DataType.HALF:
-            builder.fp16_mode = True
+            config.set_flag(trt.BuilderFlag.FP16)
+        builder.max_batch_size = batch_size
 
-        uff_parser.register_input("Input", (3, model_width, model_height))
-        uff_parser.register_output("MarkOutput_0")
-        uff_parser.parse(uff_model_path, network)
+        assert uff_parser.register_input("Input", (3, model_width, model_height), trt.tensorrt.UffInputOrder.NCHW)
+        assert uff_parser.register_output("MarkOutput_0")
+        assert uff_parser.parse(uff_model_path, network)
 
-        return builder.build_cuda_engine(network)
+        if TRT_MAIN_VERSION < 8:
+            return builder.build_engine(network, config)
+        else:
+            plan = builder.build_serialized_network(network, config)
+            return runtime.deserialize_cuda_engine(plan)
 
 
 def save_engine(engine, engine_dest_path):
@@ -51,32 +60,35 @@ TRT_PRECISION_TO_DATATYPE = {
 
 if __name__ == '__main__':
     # Define script command line arguments
-    parser = argparse.ArgumentParser(description='Utility to build TensorRT engine prior to inference.')
+    parser = argparse.ArgumentParser(description='Utility to build TensorRT engine prior to inference.',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-i', "--input",
                         dest='uff_model_path', metavar='UFF_MODEL_PATH', required=True,
                         help='preprocessed TensorFlow model in UFF format')
     parser.add_argument('-p', '--precision', type=int, choices=[32, 16], default=32,
-                        help='desired TensorRT float precision to build an engine with')
+                        help='desired TensorRT float precision to build an engine')
     parser.add_argument('-b', '--batch-size', type=int, default=1,
                         help='max TensorRT engine batch size')
+    parser.add_argument("-w", "--workspace", default=1024, type=int,
+                        help="The max memory workspace size to allow in Mb")
     parser.add_argument('-mw', '--model-width', type=int, default=300,
                         help='SSD model width')
     parser.add_argument('-mh', '--model-height', type=int, default=300,
                         help='SSD model height')
     parser.add_argument("-o", "--output", dest='trt_engine_path',
                         help="path of the output file",
-                        default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "engine.buf"))
+                        default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "engine.trt"))
 
     # Parse arguments passed
     args = parser.parse_args()
 
     # Build TensorRT engine
-    print("Building TensorRT engine. This may take few minutes.")
+    print("Building TensorRT engine. This may take a few minutes.")
     trt.init_libnvinfer_plugins(TRT_LOGGER, '')
     trt_engine = build_engine(
         uff_model_path=args.uff_model_path,
         trt_engine_datatype=TRT_PRECISION_TO_DATATYPE[args.precision],
-        batch_size=args.batch_size,
+        batch_size=args.batch_size, workspace=args.workspace,
         model_width=args.model_width, model_height=args.model_height)
     if trt_engine is not None:
         # Save the engine to file

--- a/watsor/engine.py
+++ b/watsor/engine.py
@@ -14,11 +14,9 @@ TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
 TRT_MAIN_VERSION = int(trt.__version__[0])
 
 
-def build_engine(uff_model_path, trt_engine_datatype, batch_size, workspace, model_width, model_height):
+def build_engine(model_path, trt_engine_datatype, workspace, model_width, model_height):
     with trt.Builder(TRT_LOGGER) as builder, \
-            builder.create_network() as network, \
             builder.create_builder_config() as config, \
-            trt.UffParser() as uff_parser, \
             trt.Runtime(TRT_LOGGER) as runtime:
         if TRT_MAIN_VERSION < 8:
             config.max_workspace_size = workspace * (1 << 20)
@@ -26,11 +24,25 @@ def build_engine(uff_model_path, trt_engine_datatype, batch_size, workspace, mod
             config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace * (1 << 20))
         if trt_engine_datatype == trt.DataType.HALF:
             config.set_flag(trt.BuilderFlag.FP16)
-        builder.max_batch_size = batch_size
 
-        assert uff_parser.register_input("Input", (3, model_width, model_height), trt.tensorrt.UffInputOrder.NCHW)
-        assert uff_parser.register_output("MarkOutput_0")
-        assert uff_parser.parse(uff_model_path, network)
+        _, file_extension = os.path.splitext(model_path)
+        if file_extension.lower() == '.uff':
+            network = builder.create_network()
+
+            parser = trt.UffParser()
+
+            assert parser.register_input('Input', (3, model_width, model_height), trt.tensorrt.UffInputOrder.NCHW)
+            assert parser.register_output('MarkOutput_0')
+            assert parser.parse(model_path, network)
+        elif file_extension.lower() == '.onnx':
+            network_flags = (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+            network = builder.create_network(network_flags)
+
+            parser = trt.OnnxParser(network, TRT_LOGGER)
+
+            assert parser.parse_from_file(model_path)
+        else:
+            assert False, 'Unsupported model format'
 
         if TRT_MAIN_VERSION < 8:
             return builder.build_engine(network, config)
@@ -62,35 +74,34 @@ if __name__ == '__main__':
     # Define script command line arguments
     parser = argparse.ArgumentParser(description='Utility to build TensorRT engine prior to inference.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-i', "--input",
-                        dest='uff_model_path', metavar='UFF_MODEL_PATH', required=True,
-                        help='preprocessed TensorFlow model in UFF format')
+    parser.add_argument('-i', '--input',
+                        dest='model_path', metavar='MODEL_PATH', required=True,
+                        help='preprocessed TensorFlow model in UFF or ONNX format')
     parser.add_argument('-p', '--precision', type=int, choices=[32, 16], default=32,
                         help='desired TensorRT float precision to build an engine')
-    parser.add_argument('-b', '--batch-size', type=int, default=1,
-                        help='max TensorRT engine batch size')
-    parser.add_argument("-w", "--workspace", default=1024, type=int,
-                        help="The max memory workspace size to allow in Mb")
+    parser.add_argument('-w', '--workspace', default=1024, type=int,
+                        help='The max memory workspace size to allow in Mb')
     parser.add_argument('-mw', '--model-width', type=int, default=300,
-                        help='SSD model width')
+                        help='model image width (UFF only)')
     parser.add_argument('-mh', '--model-height', type=int, default=300,
-                        help='SSD model height')
-    parser.add_argument("-o", "--output", dest='trt_engine_path',
-                        help="path of the output file",
-                        default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "engine.trt"))
+                        help='model image height (UFF only)')
+    parser.add_argument('-o', '--output', dest='trt_engine_path',
+                        help='path of the output file',
+                        default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'engine.trt'))
 
     # Parse arguments passed
     args = parser.parse_args()
 
     # Build TensorRT engine
-    print("Building TensorRT engine. This may take a few minutes.")
+    print('Building TensorRT engine from {}. This may take a few minutes.'.format(args.model_path))
     trt.init_libnvinfer_plugins(TRT_LOGGER, '')
     trt_engine = build_engine(
-        uff_model_path=args.uff_model_path,
+        model_path=args.model_path,
         trt_engine_datatype=TRT_PRECISION_TO_DATATYPE[args.precision],
-        batch_size=args.batch_size, workspace=args.workspace,
-        model_width=args.model_width, model_height=args.model_height)
+        workspace=args.workspace,
+        model_width=args.model_width,
+        model_height=args.model_height)
     if trt_engine is not None:
         # Save the engine to file
         save_engine(trt_engine, args.trt_engine_path)
-        print("TensorRT engine saved to {}".format(args.trt_engine_path))
+        print('TensorRT engine saved to {}'.format(args.trt_engine_path))

--- a/watsor/main_for_gpu.py
+++ b/watsor/main_for_gpu.py
@@ -14,14 +14,16 @@ if __name__ == '__main__':
 
     args, unknown = parser.parse_known_args()
 
-    if os.path.isfile(os.path.join(args.model_path, 'gpu.uff')) and not \
-            os.path.isfile(os.path.join(args.model_path, 'gpu.trt')):
-        engine = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'engine.py')
-        subprocess.run(['python3', '-u', engine,
-                        '-i', os.path.join(args.model_path, 'gpu.uff'),
-                        '-o', os.path.join(args.model_path, 'gpu.trt'),
-                        '-p', os.getenv('TRT_FLOAT_PRECISION', '32')
-                        ], check=True)
+    for ext in ('onnx', 'uff'):
+        if os.path.isfile(os.path.join(args.model_path, 'gpu.{}'.format(ext))) and not \
+                os.path.isfile(os.path.join(args.model_path, 'gpu.trt')):
+            engine = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'engine.py')
+            subprocess.run(['python3', '-u', engine,
+                            '-i', os.path.join(args.model_path, 'gpu.{}'.format(ext)),
+                            '-o', os.path.join(args.model_path, 'gpu.trt'),
+                            '-p', os.getenv('TRT_FLOAT_PRECISION', '32')
+                            ], check=True)
+            break
 
     from watsor.main import Application
 

--- a/watsor/main_for_gpu.py
+++ b/watsor/main_for_gpu.py
@@ -15,11 +15,11 @@ if __name__ == '__main__':
     args, unknown = parser.parse_known_args()
 
     if os.path.isfile(os.path.join(args.model_path, 'gpu.uff')) and not \
-            os.path.isfile(os.path.join(args.model_path, 'gpu.buf')):
+            os.path.isfile(os.path.join(args.model_path, 'gpu.trt')):
         engine = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'engine.py')
         subprocess.run(['python3', '-u', engine,
                         '-i', os.path.join(args.model_path, 'gpu.uff'),
-                        '-o', os.path.join(args.model_path, 'gpu.buf'),
+                        '-o', os.path.join(args.model_path, 'gpu.trt'),
                         '-p', os.getenv('TRT_FLOAT_PRECISION', '32')
                         ], check=True)
 


### PR DESCRIPTION
Watsor TensorRT detector has been upgraded to support latest TensorRT 8. It is still backward compatible with TensoRT 7. TensorRT 8 supports a lot more object detection models including Single Shot Detector and Faster R-CNN. The list of supported model can be found [here](https://github.com/NVIDIA/TensorRT/tree/8.5.3/samples/python/tensorflow_object_detection_api#create-onnx-graph).

UFF format is deprecated in favour of ONNX. Watsor can still build TensorRT engine for both model types. However, while UFF model can be just downloaded, ONNX model has to be converted first. The workflow to convert a model is basically TensorFlow > ONNX > TensorRT, and so parts of this process require TensorFlow to be installed. How to do that is well explained in this [guide](https://github.com/NVIDIA/TensorRT/tree/8.5.3/samples/python/tensorflow_object_detection_api). When ONNX model is ready, rename it to `gpu.onnx` and put in `/model` folder. Remove `gpu.trt` file (if present) to let Watsor rebuild the engine.

Docker base image is now Ubuntu 20.04. 

#### Breaking change

Docker image for Nvidia Jetson devices seems incompatible with Jetson Nano, because L4T base image no longer brings CUDA, CuDNN and TensorRT from the host file system. These libraries are now baked into Docker image, where the most recent version of them inherits JetPack 5.0 and Ubuntu 20.04. Jetson Nano is still uses JetPack 4.4.1 and Ubuntu 18.04, so until Nvidia provides an upgrade, it can not run the new Docker image.

As as workaround, on top of `smirnou/watsor.jetson:1.0.6` image one can create an image with the latest Watsor's code or upgrade Watsor's Python module right in the container. However, it will not be able to run ONNX models since CUDA and TensorRT are still outdated in the host Jeson Nano system.